### PR TITLE
Add global color guidance

### DIFF
--- a/base-knowledge.md
+++ b/base-knowledge.md
@@ -27,3 +27,8 @@ JavaScript defaults are aggregated in `blocks-config/blocks-attributes/getBlocks
 - ultimate-addons-for-gutenberg/includes/blocks/buttons-child/block.php
 - ultimate-addons-for-gutenberg/includes/blocks/buttons-child/attributes.php
 - ultimate-addons-for-gutenberg/includes/blocks/buttons-child/frontend.css.php
+
+### Spectra global colors
+Spectra provides theme-wide color presets referenced as CSS variables.
+Use `var(--ast-global-color-<n>)` for background, text and border colors
+throughout blocks. Gradients cannot consume these variables directly.

--- a/examples/buttons.notes.md
+++ b/examples/buttons.notes.md
@@ -13,6 +13,8 @@
 - Layout settings: `align`, `gap`, `stack`, `flexWrap`.
 - Typography: `fontFamily`, `fontSize`, `lineHeight`, `fontWeight`.
 - Each child button has its own `block_id` and styling properties.
+- Apply Spectra global colors using `var(--ast-global-color-<n>)` for
+  background, text and border. See [base-knowledge.md](../base-knowledge.md#spectra-global-colors).
 
 ## Valid markup example
 Spectra expects matching identifiers between JSON `block_id` and the `uagb-block-` class, but IDs may be omitted. Use empty strings to let Spectra generate them automatically:


### PR DESCRIPTION
## Summary
- document Spectra global color variables
- remind about applying global colors in buttons notes

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6870211fba308333bce0c6f50ff7ebab